### PR TITLE
Resolve tokenization issues causing BitFunnel parser crashes

### DIFF
--- a/src/test/java/org/bitfunnel/workbench/CorpusTest.java
+++ b/src/test/java/org/bitfunnel/workbench/CorpusTest.java
@@ -61,15 +61,15 @@ public class CorpusTest
    */
   public void testWikipediaToCorpus() {
     String wikipedia =
-        "<doc id=\"123\" url=\"http://www.bitfunnel.org/123\" title=\"one\">\n" +
-            "This is the body text.\n" +
+        "<doc id=\"123\" url=\"http://www.bitfunnel.org/123\" title=\"w&i|k(i)p-e\\d:ia two\">\n" +
+            "This is the body:text.\n" +
             "</doc>\n" +
             "<doc id=\"456\" url=\"http://www.bitfunnel.org/456\" title=\"two\">\n" +
             "Some more body text.\n" +
             "</doc>\n";
 
     byte[] expected =
-        ("000000000000007b\00000\000one\000\00001\000body\000text\000\000\000" +
+        ("000000000000007b\00000\000w\000i\000k\000i\000p\000e\000d\000ia\000two\000\00001\000body\000text\000\000\000" +
             "00000000000001c8\00000\000two\000\00001\000some\000more\000body\000text\000\000\000" +
             "\000").getBytes(StandardCharsets.UTF_8);
 


### PR DESCRIPTION
The corpus as processed by the current version of Workbench contains
characters (mostly punctuation) that cause the BitFunnel parser to
crash. This commit will cause Workbench to handle these cases correctly.

There are 2 issues at the root of this problem: first, the Lucene
analyzer (which we use to generate the BitFunnel chunk files) attempts
to preserve URLs, and so colons are not removed from the middle of a
term such as `Wikipedia:dump`. This causes our parser to crash. Since
Luecene does remove the colon when it does not seem to appear in a URI,
we simply have removed colons from all terms.

Second, we are not using the Lucene tokenizer to process article titles.
This leaves a wide variety of puntuation in the corpus which crashes the
tokenizer. In the new version of the corpus, the title is tokenized to
avoid such problems.
